### PR TITLE
Add auto-generated SECRET_KEY env var

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,7 @@ services:
   env: docker
   dockerfilePath: ./server/Dockerfile
   dockerContext: ./server
+  autoDeploy: false
   envVars:
   - key: IS_BEHIND_PROXY
     value: 1
@@ -26,10 +27,13 @@ services:
     fromDatabase:
       name: posthog
       property: connectionString
+  - key: SECRET_KEY
+    generateValue: true
 
 - type: pserv
   name: posthog-redis
   env: docker
+  autoDeploy: false
   repo: https://github.com/render-examples/redis.git
   disk:
     name: data
@@ -42,6 +46,7 @@ services:
   dockerfilePath: ./worker/Dockerfile
   dockerContext: ./worker
   numInstances: 1
+  autoDeploy: false
   envVars:
   - key: POSTHOG_REDIS_HOST
     fromService:
@@ -57,6 +62,8 @@ services:
     fromDatabase:
       name: posthog
       property: connectionString
+  - key: SECRET_KEY
+    generateValue: true
 
 # See https://render.com/docs/deploy-posthog#scaling-posthogs-worker
 # if you need to scale the background worker and replace the worker service
@@ -82,6 +89,8 @@ services:
 #        fromDatabase:
 #          name: posthog
 #          property: connectionString
+#      - key: SECRET_KEY
+#        generateValue: true
 #
 #  - type: worker-celery
 #    name: posthog-worker-celery
@@ -103,3 +112,5 @@ services:
 #        fromDatabase:
 #          name: posthog
 #          property: connectionString
+#      - key: SECRET_KEY
+#        generateValue: true


### PR DESCRIPTION
Add `SECRET_KEY` env var, required by the latest version.

Also add `autoDeploy: false` to prevent master changes from updating existing servers.
