### PR TITLE
Use standard DB plan instead of starter

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,8 @@ databases:
 - name: posthog
   databaseName: posthog
   user: posthog
-
+  plan: standard
+  
 services:
 - type: web
   name: posthog

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ databases:
 - name: posthog
   databaseName: posthog
   user: posthog
-  plan: standard
+  plan: standard # posthog can quickly use up hundreds of MBs of disk space
   
 services:
 - type: web


### PR DESCRIPTION
The docs suggest that Posthog uses [~100MB/million requests](https://posthog.com/docs/deployment/scaling-posthog). The starter plan will likely fill up pretty quickly in most cases. This PR updates the `render.yaml` to use a more appropriately sized database for Posthog.