### PR TITLE
Define PORT environment variable

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,8 @@ services:
   envVars:
   - key: IS_BEHIND_PROXY
     value: 1
+  - key: PORT
+    value: 80
   - key: POSTHOG_REDIS_HOST
     fromService:
       name: posthog-redis


### PR DESCRIPTION
This ensures public web traffic is forwarded to the correct port for the web service