### PR TITLE
Migrate during build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,15 @@
 FROM posthog/posthog:latest
 
-COPY migrate-and-serve.sh ./bin/
+ARG DATABASE_URL
+ARG POSTHOG_REDIS_HOST
+ARG POSTHOT_REDIS_PORT
+ARG SECRET_KEY
 
-CMD ["./bin/migrate-and-serve.sh"]
+ENV DATABASE_URL=$DATABASE_URL
+ENV POSTHOG_REDIS_HOST=$POSTHOG_REDIS_HOST
+ENV POSTHOG_REDIS_PORT=$POSTHOG_REDIS_PORT
+ENV SECRET_KEY=$SECRET_KEY
+
+RUN ./bin/docker-migrate
+
+CMD ["./bin/docker-server"]

--- a/server/migrate-and-serve.sh
+++ b/server/migrate-and-serve.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-./bin/docker-migrate
-./bin/docker-server
-

--- a/worker-beat/Dockerfile
+++ b/worker-beat/Dockerfile
@@ -1,3 +1,0 @@
-FROM posthog/posthog:latest
-
-CMD ["./bin/docker-worker-beat"]

--- a/worker-celery/Dockerfile
+++ b/worker-celery/Dockerfile
@@ -1,3 +1,0 @@
-FROM posthog/posthog:latest
-
-CMD ["./bin/docker-worker-celery"]


### PR DESCRIPTION
This prevents race conditions where the migration could be run twice through port detection.