### PR TITLE
Pull `latest-release` image tag

### DIFF
--- a/plugin-server/Dockerfile
+++ b/plugin-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM posthog/plugin-server:latest
+FROM posthog/plugin-server:latest-release
 
 ARG DATABASE_URL
 ARG POSTHOG_REDIS_HOST

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM posthog/posthog:latest
+FROM posthog/posthog:latest-release
 
 ARG DATABASE_URL
 ARG POSTHOG_REDIS_HOST

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,3 +1,3 @@
-FROM posthog/posthog:latest
+FROM posthog/posthog:latest-release
 
 CMD ["./bin/docker-worker"]


### PR DESCRIPTION
Currently the Render deployments pull the `latest` Docker images (which pull directly from `master`), but this is not intended as stable production-grade deployments for self-hosted users. These deployments should pull from the latest officially published release `latest-release` instead.


CC @macobo @fuziontech