### PR TITLE
Adds an archive note to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***At the request of the PostHog team, we are archiving this repository. Please see [PostHog's GitHub repository](https://github.com/PostHog/posthog) for the current version of PostHog.***
+
 # Deploy PostHog on Render
 
 This repo can be used to deploy [PostHog] on Render.


### PR DESCRIPTION
The PostHog team asked us to remove this example deploy because it does not work on Render and they can no loner maintain it.